### PR TITLE
Install script to simplify installing packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ -z $BASH_VERSION ] ; then
+	echo -e "You must run this script using bash." 1>&2
+	exit 1
+fi
+
+
+# Make sure we are running as superuser
+if [[ $EUID -ne 0 ]]; then
+	echo -e "This script must be run using sudo." 1>&2
+	exit 1
+fi
+
+apt-get update
+
+apt-get install --no-install-recommends python-virtualenv
+python -m virtualenv --no-site-packages venv
+source venv/bin/activate
+
+pip install ez_setup
+apt-get install python-dev libpq-dev
+easy_install hashlib
+pip install plyvel
+pip install base58
+easy_install pysqlite
+
+echo -e "Run source venv/bin/activate in your terminal before executing btcposbal2csv commands"
+

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ python btcposbal2csv.py /home/USER/.bitcoin/chainstate /home/USER/addresses_with
 
 #### Converting to RIPEMD160
 Per request, I'm adding script which is able to convert BTC address to RIPEMD160 representation.
-BTC address must be in fist column, RIPEMD160 is added to csv. Output goes to stdout.
+BTC address must be in first column, RIPEMD160 is added to csv. Output goes to stdout.
 
 Example:
 ```

--- a/readme.md
+++ b/readme.md
@@ -7,13 +7,7 @@ python 2.7
 pip  
 
 #### To install:  
-run pip install -r requirements.txt
-
-or install following packages with pip manualy
-* hashlib
-* plyvel
-* base58
-* sqlite3
+run sudo ./install.sh
 
 #### Usage
 To use you will need copy of chainstate database as created by [bitcoin core](https://bitcoin.org/en/bitcoin-core/)


### PR DESCRIPTION
It took me about 15 minutes to resolve all the errors I got trying to install the packages required for this script (which is very useful and surprisingly fast, so thank you graymauser).

I've added an install.sh script which sets up a Python venv and runs the correct commands to install the dependencies and enable the btcposbal2csv.py script.

Tested on Ubuntu 19.04 with Python 2.7.16